### PR TITLE
CHK-1050-postepay-polling

### DIFF
--- a/api-spec/pgs_api.yaml
+++ b/api-spec/pgs_api.yaml
@@ -145,9 +145,13 @@ components:
       required:
         - channel
         - authOutcome
+        - logoResourcePath
         - urlRedirect
         - error
       properties:
+        logoResourcePath:
+          type: string
+          description: logo
         channel:
           type: string
           description: request payment channel (APP or WEB)

--- a/src/models/transactions.ts
+++ b/src/models/transactions.ts
@@ -1,12 +1,3 @@
-export interface PollingResponseEntity {
-  channel: string;
-  urlRedirect: string | null | undefined;
-  clientResponseUrl: string;
-  logoResourcePath: string;
-  authOutcome: string | null | undefined;
-  error: string | null | undefined;
-}
-
 export enum Channel {
   WEB = "WEB",
   APP = "APP"

--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -2,25 +2,21 @@ import { DeferredPromise } from "@pagopa/ts-commons//lib/promises";
 import { Millisecond } from "@pagopa/ts-commons//lib/units";
 import { createClient } from "../../generated/pgs/client";
 import { getConfigOrThrow } from "../config/config";
-import { constantPollingWithPromisePredicateFetch } from "../config/fetch";
+import { constantPollingWithPromisePredicateFetch } from "../api/fetch";
 
 const conf = getConfigOrThrow();
 const retries: number = 10;
 const delay: number = 3000;
 const timeout: Millisecond = conf.API_TIMEOUT as Millisecond;
 
-export const pgsClient = createClient({
+export const postepayPgsClient = createClient({
   baseUrl: conf.API_HOST,
   fetchApi: constantPollingWithPromisePredicateFetch(
     DeferredPromise<boolean>().e1,
     retries,
     delay,
     timeout,
-    async (r: Response): Promise<boolean> => {
-      return (
-        r.status === 200 
-      );
-    }
+    async (r: Response): Promise<boolean> => r.status !== 200
   ),
-  basePath: ""
+  basePath: conf.API_BASEPATH
 });

--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -1,23 +1,26 @@
-// import { agent } from "@pagopa/ts-commons";
-// import {
-//   AbortableFetch,
-//   setFetchTimeout,
-//   toFetch
-// } from "@pagopa/ts-commons/lib/fetch";
-// import { Millisecond } from "@pagopa/ts-commons/lib/units";
-// import { createClient } from "../../../generated/definitions/gateway-transactions-api/client";
-// import { getConfig } from "../config";
+import { DeferredPromise } from "@pagopa/ts-commons//lib/promises";
+import { Millisecond } from "@pagopa/ts-commons//lib/units";
+import { createClient } from "../../generated/pgs/client";
+import { getConfigOrThrow } from "../config/config";
+import { constantPollingWithPromisePredicateFetch } from "../config/fetch";
 
-// const abortableFetch = AbortableFetch(agent.getHttpFetch(process.env));
-// const fetchWithTimeout = toFetch(
-//   setFetchTimeout(getConfig().API_TIMEOUT as Millisecond, abortableFetch)
-// );
-// // tslint:disable-next-line: no-any
-// const fetchApi: typeof fetchWithTimeout =
-//   fetch as any as typeof fetchWithTimeout;
+const conf = getConfigOrThrow();
+const retries: number = 10;
+const delay: number = 3000;
+const timeout: Millisecond = conf.API_TIMEOUT as Millisecond;
 
-// export const apiTransactionsClient = createClient({
-//   baseUrl: getConfig().API_HOST,
-//   basePath: getConfig().API_BASEPATH,
-//   fetchApi
-// });
+export const pgsClient = createClient({
+  baseUrl: conf.API_HOST,
+  fetchApi: constantPollingWithPromisePredicateFetch(
+    DeferredPromise<boolean>().e1,
+    retries,
+    delay,
+    timeout,
+    async (r: Response): Promise<boolean> => {
+      return (
+        r.status === 200 
+      );
+    }
+  ),
+  basePath: ""
+});

--- a/src/utils/api/fetch.ts
+++ b/src/utils/api/fetch.ts
@@ -1,16 +1,52 @@
-import * as TE from "fp-ts/TaskEither";
+/**
+ * This module exports an instance of fetch augmented with
+ * timeout and retries with exponential backoff.
+ */
 import * as E from "fp-ts/Either";
+import * as TE from "fp-ts/TaskEither";
+import { pipe } from "fp-ts/function";
 import { calculateExponentialBackoffInterval } from "@pagopa/ts-commons/lib/backoff";
-import { retriableFetch } from "@pagopa/ts-commons/lib/fetch";
+import {
+  AbortableFetch,
+  retriableFetch,
+  setFetchTimeout,
+  toFetch
+} from "@pagopa/ts-commons/lib/fetch";
 import {
   RetriableTask,
-  withRetries,
-  TransientError
+  TransientError,
+  withRetries
 } from "@pagopa/ts-commons/lib/tasks";
-import { pipe } from "fp-ts/function";
+import { Millisecond } from "@pagopa/ts-commons/lib/units";
+import { getConfigOrThrow } from "../config/config";
 
-// TODO: use timeoutFetch
-// const API_TIMEOUT = getConfigOrThrow().API_TIMEOUT as Millisecond;
+//
+// Returns a fetch wrapped with timeout and retry logic
+//
+const API_TIMEOUT = getConfigOrThrow().API_TIMEOUT as Millisecond;
+
+export function retryingFetch(
+  fetchApi: typeof fetch,
+  timeout: Millisecond = API_TIMEOUT,
+  maxRetries: number = 3
+): typeof fetch {
+  // a fetch that can be aborted and that gets cancelled after fetchTimeoutMs
+  const abortableFetch = AbortableFetch(fetchApi);
+  const timeoutFetch = toFetch(setFetchTimeout(timeout, abortableFetch));
+  // configure retry logic with default exponential backoff
+  // @see https://github.com/pagopa/io-ts-commons/blob/master/src/backoff.ts
+  const exponentialBackoff = calculateExponentialBackoffInterval();
+  const retryLogic = withRetries<Error, Response>(
+    maxRetries,
+    exponentialBackoff
+  );
+  const retryWithTransient429s = retryLogicForTransientResponseError(
+    (_: Response) => _.status === 429,
+    retryLogic
+  );
+  return retriableFetch(retryWithTransient429s)(timeoutFetch as any);
+}
+
 //
 // Fetch with transient error handling. Handle error that occurs once or at unpredictable intervals.
 //
@@ -35,24 +71,98 @@ export function retryLogicForTransientResponseError(
     );
 }
 
-export function retryingFetch(
-  // fetchApi: typeof fetch,
-  // timeout: Millisecond = API_TIMEOUT,
-  maxRetries: number = 3
-): typeof fetch {
-  // a fetch that can be aborted and that gets cancelled after fetchTimeoutMs
-  // const abortableFetch = AbortableFetch(fetchApi);
-  // const timeoutFetch = toFetch(setFetchTimeout(timeout, abortableFetch));
-  // configure retry logic with default exponential backoff
-  // @see https://github.com/pagopa/io-ts-commons/blob/master/src/backoff.ts
-  const exponentialBackoff = calculateExponentialBackoffInterval();
-  const retryLogic = withRetries<Error, Response>(
-    maxRetries,
-    exponentialBackoff
-  );
-  const retryWithTransient429s = retryLogicForTransientResponseError(
-    (_: Response) => _.status === 429,
+//
+// Given predicate that return a boolean promise, fetch with transient error handling.
+// Handle error that occurs once or at unpredictable intervals.
+//
+export function retryLogicOnPromisePredicate(
+  p: (r: Response) => Promise<boolean>,
+  retryLogic: (
+    t: RetriableTask<Error, Response>,
+    shouldAbort?: Promise<boolean>
+  ) => TE.TaskEither<Error | "max-retries" | "retry-aborted", Response>
+): typeof retryLogic {
+  return (t: RetriableTask<Error, Response>, shouldAbort?: Promise<boolean>) =>
+    retryLogic(
+      pipe(
+        t,
+        TE.chain((r: Response) =>
+          pipe(
+            TE.tryCatch(
+              () => p(r),
+              () => TransientError
+            ),
+            TE.chain<Error | TransientError, boolean, Response>((d) =>
+              TE.fromEither(d ? E.left(TransientError) : E.right(r))
+            )
+          )
+        )
+      ),
+      shouldAbort
+    );
+}
+
+// This is a fetch with timeouts, constant backoff and with the logic
+// that handles 404s as transient errors, this "fetch" must be passed to
+// createFetchRequestForApi when creating "getPaymentId"
+
+export const constantPollingWithPromisePredicateFetch = (
+  shouldAbort: Promise<boolean>,
+  retries: number,
+  delay: number,
+  timeout: Millisecond = API_TIMEOUT,
+  condition: (r: Response) => Promise<boolean>
+) => {
+  // fetch client that can be aborted for timeout
+  const abortableFetch = AbortableFetch((global as any).fetch);
+  const timeoutFetch = toFetch(setFetchTimeout(timeout, abortableFetch));
+
+  // use a constant backoff
+  const constantBackoff = () => delay as Millisecond;
+  const retryLogic = withRetries<Error, Response>(retries, constantBackoff);
+
+  // use to define transient errors
+  const retryWithPromisePredicate = retryLogicOnPromisePredicate(
+    condition,
     retryLogic
   );
-  return retriableFetch(retryWithTransient429s)(fetch);
+
+  return retriableFetch(
+    retryWithPromisePredicate,
+    shouldAbort
+  )(timeoutFetch as any);
+};
+
+export interface ITransientFetchOpts {
+  numberOfRetries: number;
+  httpCodeMapToTransient: number;
+  delay: Millisecond;
+  timeout: Millisecond;
 }
+
+export const transientConfigurableFetch = (
+  myFetch: typeof fetch,
+  options: ITransientFetchOpts = {
+    numberOfRetries: 3,
+    httpCodeMapToTransient: 429,
+    delay: 10 as Millisecond,
+    timeout: API_TIMEOUT
+  }
+) => {
+  const abortableFetch = AbortableFetch(myFetch);
+  const timeoutFetch = toFetch(
+    setFetchTimeout(options.timeout, abortableFetch)
+  );
+  const constantBackoff = () => options.delay;
+  const retryLogic = withRetries<Error, Response>(
+    options.numberOfRetries,
+    constantBackoff
+  );
+  // makes the retry logic map specific http error code to transient errors (by default only
+  // timeouts are transient)
+  const retryWithTransientError = retryLogicForTransientResponseError(
+    (response) => response.status === options.httpCodeMapToTransient,
+    retryLogic
+  );
+  return retriableFetch(retryWithTransientError)(timeoutFetch as typeof fetch);
+};

--- a/src/utils/apiService.ts
+++ b/src/utils/apiService.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { getConfigOrThrow } from "./config/config";
-
 export function transactionFetch(
   url: string,
   onResponse: (data: any) => void,


### PR DESCRIPTION
List of change
Changed the client to execute the call  /request-payments/:requestId
For execute the polling has been used the generated client by openapi and the fp-ts library
The tests were performed locally.

