### PR TITLE
[CHK-1052] fix: unnecessary polling on 404 error

### DIFF
--- a/src/pages/Vpos.tsx
+++ b/src/pages/Vpos.tsx
@@ -81,7 +81,7 @@ const handleMethodMessage = async (e: MessageEvent<any>) => {
   pipe(
     E.fromPredicate(
       (e1: MessageEvent<any>) =>
-        // e1.origin === window.location.origin &&
+        e1.origin === window.location.origin &&
         e1.data === "3DS.Notification.Received",
       E.toError
     )(e),

--- a/src/pages/Vpos.tsx
+++ b/src/pages/Vpos.tsx
@@ -25,6 +25,9 @@ import {
   resumePaymentRequestTask
 } from "../utils/transactions/transactionHelpers";
 import { vposPgsClient } from "../utils/api/client";
+import { getConfigOrThrow } from "../utils/config/config";
+
+const conf = getConfigOrThrow();
 
 const layoutStyle: SxProps<Theme> = {
   display: "flex",
@@ -81,8 +84,7 @@ const handleMethodMessage = async (e: MessageEvent<any>) => {
   pipe(
     E.fromPredicate(
       (e1: MessageEvent<any>) =>
-        e1.origin === window.location.origin &&
-        e1.data === "3DS.Notification.Received",
+        e1.origin === conf.API_HOST && e1.data === "3DS.Notification.Received",
       E.toError
     )(e),
     E.fold(

--- a/src/pages/Vpos.tsx
+++ b/src/pages/Vpos.tsx
@@ -132,13 +132,19 @@ export default function Vpos() {
           vposPgsClient.GetVposPaymentRequest({
             requestId: id as string
           }),
-        () => onError()
+        () => onError() // Polling attempt exausted
       ),
-      TE.map((errorOrResponse) =>
+      TE.map((response) =>
         pipe(
-          errorOrResponse,
-          E.map((response) =>
-            onResponse(response.value as PaymentRequestVposResponse)
+          response,
+          E.map((r) =>
+            pipe(
+              PaymentRequestVposResponse.decode(r.value),
+              E.fold(
+                (_err) => onError(),
+                (r) => onResponse(r as PaymentRequestVposResponse)
+              )
+            )
           )
         )
       )

--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -62,7 +62,7 @@ export const vposPgsClient = createClient({
     async (r: Response): Promise<boolean> => {
       const jsonResponse = await r.clone().json();
       return (
-        r.status !== 200 ||
+        (r.status !== 200 && r.status !== 404) ||
         pipe(
           PaymentRequestVposResponse.decode(jsonResponse),
           E.fold(


### PR DESCRIPTION
- The GET on `https://api.dev.platform.pagopa.it/payment-transactions-gateway/external/v1/request-payments/vpos/<ID>` with a 404 error was handled as transient error. That behavior is unnecessary because a 404 is a final state, this fix will stop the polling whenever a 404 is returned