### PR TITLE
CHK-1751: get token from sessionStorage after 3ds auth

### DIFF
--- a/src/pages/Vpos.tsx
+++ b/src/pages/Vpos.tsx
@@ -164,7 +164,7 @@ const handleMethodMessage = async (e: MessageEvent<any>) => {
 export default function Vpos() {
   const { t } = useTranslation();
   const { id } = useParams();
-  const bearerAuth = getToken(window.location.href);
+  const bearerAuth = getToken(window.location.href) || "";
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
   const [polling, setPolling] = React.useState(true);
   const [methodTimeoutElapsed, setMethodTimeoutElapsed] = React.useState(false);

--- a/src/pages/XPay.tsx
+++ b/src/pages/XPay.tsx
@@ -25,7 +25,7 @@ const layoutStyle: SxProps<Theme> = {
 export default function XPay() {
   const { t } = useTranslation();
   const { id } = useParams();
-  const bearerAuth = getToken(window.location.href);
+  const bearerAuth = getToken(window.location.href) || "";
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
   const [polling, setPolling] = React.useState(true);
 

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,4 +1,5 @@
 import { flow } from "fp-ts/function";
+import * as O from "fp-ts/Option";
 
 /* eslint-disable functional/immutable-data */
 export function getQueryParam(query: string) {
@@ -23,4 +24,9 @@ function getHash(url: string) {
 function removeChars(subStr: string) {
   return (str: string) => str.replace(subStr, "");
 }
-export const getToken = flow(getHash, removeChars("#token="));
+export const getToken = flow(
+  getHash,
+  removeChars("#token="),
+  O.fromNullable,
+  O.getOrElse(() => sessionStorage.getItem("bearerAuth"))
+);


### PR DESCRIPTION
#### Motivation and Context

The goal of this PR is to try to get the `token` from the `sessionStorage` when it is not present in the url, for example with the redirect after 3ds.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
